### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ Work in progress...
 
 ### Running the kernel
 ```shell
-bochs -f bootsrc.txt -q
+bochs -f bochsrc.txt -q
 ```


### PR DESCRIPTION
I believe `bootsrc.txt` is a typo of `bochsrc.txt`